### PR TITLE
fix error occuring when running >status in calls

### DIFF
--- a/Commands/Call/status.js
+++ b/Commands/Call/status.js
@@ -1,4 +1,4 @@
-module.exports = (client, msg, suffix, call) => {
+module.exports = async(client, msg, suffix, call) => {
 	if (!call.pickedUp) return;
 
 	const startDate = new Date(call.startedAt);


### PR DESCRIPTION
TypeError: Cannot read property 'then' of undefined
    at module.exports (/root/dtel/Events/message.js:73:38)

because its not returning a promise